### PR TITLE
BEdita Core and Api 5.15

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     ],
     "require": {
         "php": "^8.1",
-        "bedita/core": "^5.13",
-        "bedita/api": "^5.13",
+        "bedita/core": "^5.15",
+        "bedita/api": "^5.15",
         "cakephp/cakephp": "^4.4.1"
     },
     "require-dev": {


### PR DESCRIPTION
This updates BEdita dependencies to version 5.15 (see https://github.com/bedita/bedita/releases for more details)