### PR TITLE
Handle `metadata` and file upload `options`

### DIFF
--- a/src/Index/CollectionHandler.php
+++ b/src/Index/CollectionHandler.php
@@ -12,7 +12,6 @@ use BEdita\Core\Filesystem\FilesystemRegistry;
 use BEdita\Core\Model\Entity\AsyncJob;
 use BEdita\Core\Model\Entity\ObjectEntity;
 use Brevia\BEdita\Client\BreviaClient;
-use Cake\Core\Configure;
 use Cake\Http\Client\FormData;
 use Cake\Log\LogTrait;
 use Cake\ORM\Locator\LocatorAwareTrait;
@@ -52,6 +51,7 @@ class CollectionHandler
         'collection_uuid',
         'collection_updated',
         '_meta',
+        '_joinData',
     ];
 
     /**
@@ -162,11 +162,13 @@ class CollectionHandler
             return;
         }
         $content = sprintf("%s\n%s", (string)$entity->get('title'), strip_tags((string)$entity->get('body')));
+        $defaultMetadata = ['type' => $entity->get('type')];
+        $extra = (array)$entity->get('extra');
         $body = [
             'content' => $content,
             'collection_id' => $collection->get('collection_uuid'),
             'document_id' => (string)$entity->get('id'),
-            'metadata' => ['type' => $entity->get('type')],
+            'metadata' => Hash::get($extra, 'brevia.metadata', $defaultMetadata),
         ];
         $this->client->post('/index', $body);
         $entity->set('index_updated', date('c'));
@@ -201,16 +203,18 @@ class CollectionHandler
             $stream->mime_type,
         );
         $form->addFile('file', $file);
-        $options = Configure::check('Brevia.fileOptions') ?
-            json_encode(Configure::read('Brevia.fileOptions')) : null;
+        // read metadata & options in `extra.brevia` if available
+        $extra = (array)$entity->get('extra');
+        $defaultMetadata = [
+            'type' => $entity->get('type'),
+            'file' => $stream->file_name,
+        ];
+        $options = Hash::get($extra, 'brevia.options');
         $form->addMany(array_filter([
             'collection_id' => $collection->get('collection_uuid'),
             'document_id' => (string)$entity->get('id'),
-            'metadata' => json_encode([
-                'type' => $entity->get('type'),
-                'file' => $stream->file_name,
-            ]),
-            'options' => $options,
+            'metadata' => json_encode(Hash::get($extra, 'brevia.metadata', $defaultMetadata)),
+            'options' => $options ? json_encode($options) : null,
         ]));
         $this->client->postMultipart(
             '/index/upload',

--- a/src/Index/CollectionHandler.php
+++ b/src/Index/CollectionHandler.php
@@ -12,6 +12,7 @@ use BEdita\Core\Filesystem\FilesystemRegistry;
 use BEdita\Core\Model\Entity\AsyncJob;
 use BEdita\Core\Model\Entity\ObjectEntity;
 use Brevia\BEdita\Client\BreviaClient;
+use Cake\Core\Configure;
 use Cake\Http\Client\FormData;
 use Cake\Log\LogTrait;
 use Cake\ORM\Locator\LocatorAwareTrait;
@@ -200,14 +201,17 @@ class CollectionHandler
             $stream->mime_type,
         );
         $form->addFile('file', $file);
-        $form->addMany([
+        $options = Configure::check('Brevia.fileOptions') ?
+            json_encode(Configure::read('Brevia.fileOptions')) : null;
+        $form->addMany(array_filter([
             'collection_id' => $collection->get('collection_uuid'),
             'document_id' => (string)$entity->get('id'),
             'metadata' => json_encode([
                 'type' => $entity->get('type'),
                 'file' => $stream->file_name,
             ]),
-        ]);
+            'options' => $options,
+        ]));
         $this->client->postMultipart(
             '/index/upload',
             $form


### PR DESCRIPTION
In this PR we introduce a way to handle Brevia `metadata` and file upload `options`  when adding a new document to a collection.

* if `extra.brevia.metadata` is populated, these metadata are used instead of the default by type. 
* if `extra.brevia.options` is populated, these options are used in `POST /index/upload` API request in Brevia 

Bonus track: internal relation params `_joinData` are now exlcuded from brevia `collection.cmetadata`