### PR TITLE
Add 'url' to file metadata

### DIFF
--- a/src/Command/UpdateMetadataCommand.php
+++ b/src/Command/UpdateMetadataCommand.php
@@ -1,0 +1,106 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita Brevia plugin
+ *
+ * Copyright 2024 Atlas Srl
+ */
+namespace Brevia\BEdita\Command;
+
+use Brevia\BEdita\Client\BreviaClient;
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\Log\LogTrait;
+use Cake\Utility\Hash;
+use Exception;
+
+/**
+ * Update metadata in collection contents
+ *
+ * @property \BEdita\Core\Model\Table\ObjectsTable $Collections
+ */
+class UpdateMetadataCommand extends Command
+{
+    use LogTrait;
+
+    /**
+     * Brevia API client
+     *
+     * @var \Brevia\BEdita\Client\BreviaClient
+     */
+    protected BreviaClient $client;
+
+    /**
+     * @inheritDoc
+     */
+    public $defaultTable = 'Collections';
+
+    /**
+     * @inheritDoc
+     */
+    protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        return $parser->addOption('collection', [
+                'help' => 'Collection to update (use the unique collection name)',
+                'short' => 'c',
+                'required' => true,
+            ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function initialize(): void
+    {
+        $this->client = new BreviaClient();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(Arguments $args, ConsoleIo $io)
+    {
+        $name = $args->getOption('collection');
+        $response = $this->client->get('/collections', compact('name'));
+        $collectionId = Hash::get($response->getJson(), '0.cmetadata.id');
+        if (empty($collectionId)) {
+            $io->abort(sprintf('Collection not found: %s', $name));
+        }
+        $collectionUuid = Hash::get($response->getJson(), '0.uuid');
+        $collection = $this->Collections->get($collectionId, ['contain' => ['HasDocuments']]);
+        $io->out('Start reindexing collection contents...');
+        $documents = (array)$collection->get('has_documents');
+        foreach ($documents as $doc) {
+            if ($doc->get('type') !== 'files') {
+                continue;
+            }
+            $this->log(sprintf('Updating [%s] "%s" - id: %s', $doc->get('type'), $doc->get('title'), $doc->id), 'info');
+            try {
+                $doc = $doc->getTable()->get($doc->id);
+                $path = sprintf('/index/%s/%s', $collectionUuid, $doc->id);
+                $response = $this->client->get($path);
+                $metadata = (array)Hash::get((array)$response->getJson(), '0.cmetadata');
+                if (!empty($metadata['url'])) {
+                    continue;
+                }
+                $metadata['url'] = $doc->get('media_url');
+                $this->client->post('/index/metadata', [
+                    'collection_id' => $collectionUuid,
+                    'document_id' => (string)$doc->id,
+                    'metadata' => $metadata,
+                ]);
+
+            } catch (Exception $e) {
+                $this->log(sprintf('Error updating [%s] "%s" - id: %s', $doc->get('type'), $doc->get('title'), $doc->id), 'error');
+                $this->log($e->getMessage(), 'error');
+            }
+        }
+
+        $io->out('Done');
+
+        return null;
+    }
+}

--- a/src/Command/UpdateMetadataCommand.php
+++ b/src/Command/UpdateMetadataCommand.php
@@ -92,7 +92,6 @@ class UpdateMetadataCommand extends Command
                     'document_id' => (string)$doc->id,
                     'metadata' => $metadata,
                 ]);
-
             } catch (Exception $e) {
                 $this->log(sprintf('Error updating [%s] "%s" - id: %s', $doc->get('type'), $doc->get('title'), $doc->id), 'error');
                 $this->log($e->getMessage(), 'error');

--- a/src/Index/CollectionHandler.php
+++ b/src/Index/CollectionHandler.php
@@ -229,7 +229,7 @@ class CollectionHandler
         $form->addFile('file', $file);
         // read options in `extra.brevia` if available
         $options = Hash::get((array)$entity->get('extra'), 'brevia.options');
-        $fileMetadata = ['file' => $stream->file_name];
+        $fileMetadata = ['file' => $stream->file_name, 'url' => $stream->url];
         $form->addMany(array_filter([
             'collection_id' => $collection->get('collection_uuid'),
             'document_id' => (string)$entity->get('id'),

--- a/tests/TestCase/Index/CollectionHandlerTest.php
+++ b/tests/TestCase/Index/CollectionHandlerTest.php
@@ -130,6 +130,7 @@ class CollectionHandlerTest extends TestCase
 
         $stream = new Stream();
         $stream->set('uri', 'default://test.txt', ['guard' => false]);
+        $stream->set('url', '/test.txt', ['guard' => false]);
         $stream->set('file_size', 1, ['guard' => false]);
         $entity = $this->mockEntity('files', [
             'index_updated' => null,

--- a/tests/TestCase/Job/Service/IndexFileServiceTest.php
+++ b/tests/TestCase/Job/Service/IndexFileServiceTest.php
@@ -35,6 +35,7 @@ class IndexFileServiceTest extends TestCase
 
         $stream = new Stream();
         $stream->set('uri', 'default://test.txt', ['guard' => false]);
+        $stream->set('url', '/test.txt', ['guard' => false]);
         $stream->set('file_size', 1, ['guard' => false]);
         $file = $this->mockEntity('files', [
             'index_updated' => null,


### PR DESCRIPTION
Add `url` of a file upon indexing in documenta metadata.

A new command  `UpdateMedataCommand` was created to update file metadata with `url` attribute
