### PR TITLE
Load sitemap URLs using blacklist from file

### DIFF
--- a/src/Command/ImportSitemapCommand.php
+++ b/src/Command/ImportSitemapCommand.php
@@ -112,7 +112,15 @@ class ImportSitemapCommand extends Command
         },
             (array)$collection->get('has_documents')));
         $prefix = $args->getOption('prefix');
-        $blackList = $this->loadBlackList((string)$args->getOption('black-list'));
+
+        $blackListPath = (string)$args->getOption('black-list');
+        $blackList = [];
+        if (!empty($blackListPath)) {
+            if (!file_exists($blackListPath)) {
+                $io->abort(sprintf('Blacklist file not found: %s', $blackListPath));
+            }
+            $blackList = (array)file($blackListPath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        }
 
         $xml = simplexml_load_string($content);
         $json = json_encode($xml);
@@ -179,24 +187,5 @@ class ImportSitemapCommand extends Command
         });
 
         return ['selector' => Hash::get($options, '0.selector')];
-    }
-
-    /**
-     * Load black list from file and return as array
-     *
-     * @param string $blackListPath Path to black list file
-     * @param string $collection Collection name
-     * @return array
-     */
-    protected function loadBlackList(string $blackListPath): array
-    {
-        if (empty($blackListPath)) {
-            return [];
-        }
-        if (!file_exists($blackListPath)) {
-            $this->io->abort(sprintf('Blacklist file not found: %s', $blackListPath));
-        }
-
-        return (array)file($blackListPath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
     }
 }

--- a/src/Command/ImportSitemapCommand.php
+++ b/src/Command/ImportSitemapCommand.php
@@ -92,9 +92,12 @@ class ImportSitemapCommand extends Command
         $sitemap = $args->getOption('sitemap');
         $content = '';
         if (!empty($sitemap)) {
+            if (strpos($sitemap, 'http://') !== 0 && strpos($sitemap, 'https://') !== 0 && !file_exists($sitemap)) {
+                $io->abort(sprintf('File not found: %s', $sitemap));
+            }
             $content = file_get_contents($sitemap);
             if ($content === false) {
-                $io->abort(sprintf('Error reading sitemap file: %s', $sitemap));
+                $io->abort(sprintf('Error reading sitemap URL: %s', $sitemap));
             }
         }
 


### PR DESCRIPTION
This PR adds a `--black-list` or `-b` option to the `import_sitemap` command to specify a blacklist file containing URLs to ignore.
This file is a plain text file having one URL per line

 